### PR TITLE
Improvements to Atom conversion.

### DIFF
--- a/snippets/angularjs.cson
+++ b/snippets/angularjs.cson
@@ -1,64 +1,64 @@
 '.source.js, .source.coffee':
   '$apply':
     'prefix': '.$'
-    'body': '.\\$apply($0)$TM_JAVASCRIPT_TERMINATOR'
+    'body': '.$apply($0);'
   '$broadcast':
     'prefix': '.$'
-    'body': '.\\$broadcast(\'${1:name}\', ${2:arguments})$TM_JAVASCRIPT_TERMINATOR'
+    'body': '.$broadcast(\'${1:name}\', ${2:arguments});'
   '$destroy':
     'prefix': '.$'
-    'body': '.\\$destroy()$TM_JAVASCRIPT_TERMINATOR'
+    'body': '.$destroy();'
   '$digest':
     'prefix': '.$'
-    'body': '.\\$digest()$TM_JAVASCRIPT_TERMINATOR'
+    'body': '.$digest();'
   '$emit':
     'prefix': '.$'
-    'body': '.\\$emit(\'${1:name}\', ${2:arguments})$TM_JAVASCRIPT_TERMINATOR'
+    'body': '.$emit(\'${1:name}\', ${2:arguments});'
   '$eval':
     'prefix': '.$'
-    'body': '.\\$eval($0)$TM_JAVASCRIPT_TERMINATOR'
+    'body': '.$eval($0);'
   '$evalAsync':
     'prefix': '.$'
-    'body': '.\\$evalAsync($0)$TM_JAVASCRIPT_TERMINATOR'
+    'body': '.$evalAsync($0);'
   '$new':
     'prefix': '.$'
-    'body': '.\\$new(${1:isolate})$TM_JAVASCRIPT_TERMINATOR'
+    'body': '.$new(${1:isolate});'
   '$on':
     'prefix': '.$'
-    'body': '.\\$on(\'${1:name}\', ${2:function(){$3}})$TM_JAVASCRIPT_TERMINATOR'
+    'body': '.$on(\'${1:name}\', ${2:function(){$3}});'
   '$parent':
     'prefix': '.$'
-    'body': '.\\$parent.'
+    'body': '.$parent.'
   '$root':
     'prefix': '.$'
-    'body': '.\\$root.'
+    'body': '.$root.'
   '$watch':
     'prefix': '.$'
-    'body': '.\\$watch(\'${1:name}\', function(scope, newValue, oldValue) {\n\t$0\n})$TM_JAVASCRIPT_TERMINATOR'
+    'body': '.$watch(\'${1:name}\', function(scope, newValue, oldValue) {\n\t$0\n});'
   '$http':
     'prefix': 'http'
-    'body': '\\$http(\'${1:GET|POST|PUT|DELETE}\', ${2:url}${3:, ${4:post}}, ${5:function(status, response){\n\t${6:// success}\n}}${7:, function(status, response){\n\t${8:// error}\n}})$TM_JAVASCRIPT_TERMINATOR'
+    'body': '$http(\'${1:GET|POST|PUT|DELETE}\', ${2:url}${3:, ${4:post}}, ${5:function(status, response){\n\t${6:// success}\n}}${7:, function(status, response){\n\t${8:// error}\n}});'
   'copy':
     'prefix': 'copy'
     'body': 'angular.copy(${1:source}${2:, ${3:destination}})'
   'directive':
     'prefix': 'dir'
-    'body': 'directive(\'$1\', [${3:\'$4\', }function($4){\n\t${5:// Runs during compile}\n\treturn {\n\t\t// name: \'\',\n\t\t// priority: 1,\n\t\t// terminal: true,\n\t\t// scope: {}, // {} = isolate, true = child, false/undefined = no change\n\t\t// cont­rol­ler: function(\\$scope, \\$element, \\$attrs, \\$transclue) {},\n\t\t// require: \'ngModel\', // Array = multiple requires, ? = optional, ^ = check parent elements\n\t\t// restrict: \'A\', // E = Element, A = Attribute, C = Class, M = Comment\n\t\t// template: \'\',\n\t\t// templateUrl: \'\',\n\t\t// replace: true,\n\t\t// transclude: true,\n\t\t// compile: function(tElement, tAttrs, function transclude(function(scope, cloneLinkingFn){ return function linking(scope, elm, attrs){}})),\n\t\tlink: function(\\$scope, iElm, iAttrs, controller) {\n\t\t\t$0\n\t\t}\n\t};\n}])$TM_JAVASCRIPT_TERMINATOR'
+    'body': 'directive(\'$1\', [${3:\'$4\', }function($4){\n\t${5:// Runs during compile}\n\treturn {\n\t\t// name: \'\',\n\t\t// priority: 1,\n\t\t// terminal: true,\n\t\t// scope: {}, // {} = isolate, true = child, false/undefined = no change\n\t\t// cont­rol­ler: function(\\$scope, \\$element, \\$attrs, \\$transclue) {},\n\t\t// require: \'ngModel\', // Array = multiple requires, ? = optional, ^ = check parent elements\n\t\t// restrict: \'A\', // E = Element, A = Attribute, C = Class, M = Comment\n\t\t// template: \'\',\n\t\t// templateUrl: \'\',\n\t\t// replace: true,\n\t\t// transclude: true,\n\t\t// compile: function(tElement, tAttrs, function transclude(function(scope, cloneLinkingFn){ return function linking(scope, elm, attrs){}})),\n\t\tlink: function(\\$scope, iElm, iAttrs, controller) {\n\t\t\t$0\n\t\t}\n\t};\n}]);'
   'element':
     'prefix': 'el'
-    'body': 'angular.element(${1:element})$TM_JAVASCRIPT_TERMINATOR'
+    'body': 'angular.element(${1:element});'
   'equals':
     'prefix': 'eq'
-    'body': 'angular.equals(${1:object1}, ${2:object2})$TM_JAVASCRIPT_TERMINATOR'
+    'body': 'angular.equals(${1:object1}, ${2:object2});'
   'extend':
     'prefix': 'extend'
     'body': 'angular.extend(${1:destinationObject}, ${2:sourceObject})'
   '$filter':
     'prefix': 'filter'
-    'body': '\\$filter(\'${1:currency|date|filter|json|limitTo|linky|lowercase|number|orderBy|uppercase}\')(${2:array}${3:, ${4:expression}})$TM_JAVASCRIPT_TERMINATOR'
+    'body': '$filter(\'${1:currency|date|filter|json|limitTo|linky|lowercase|number|orderBy|uppercase}\')(${2:array}${3:, ${4:expression}});'
   'forEach':
     'prefix': 'each'
-    'body': 'angular.forEach(${1:values}, function(${2:value}, ${3:key}){\n\t$0\n})$TM_JAVASCRIPT_TERMINATOR'
+    'body': 'angular.forEach(${1:values}, function(${2:value}, ${3:key}){\n\t$0\n});'
   'isArray':
     'prefix': 'is'
     'body': 'angular.isArray(${1:value})'
@@ -79,7 +79,7 @@
     'body': 'angular.isString(${1:value})'
   'lowercase':
     'prefix': 'lower'
-    'body': 'angular.lowercase(${1:string})$TM_JAVASCRIPT_TERMINATOR'
+    'body': 'angular.lowercase(${1:string});'
   'module':
     'prefix': 'mod'
     'body': '/**\n * $1 Module\n *\n * ${2:Description}\n */\nangular.module(\'$1\', [$3]).$0'
@@ -88,11 +88,11 @@
     'body': 'angular.noop'
   'uppercase':
     'prefix': 'upper'
-    'body': 'angular.uppercase(${1:string})$TM_JAVASCRIPT_TERMINATOR'
+    'body': 'angular.uppercase(${1:string});'
 '.js':
   '$routeProvider.when':
     'prefix': 'route'
-    'body': '\\$routeProvider.when(\'$1\', {template: \'$2\', controller: $3})$TM_JAVASCRIPT_TERMINATOR'
+    'body': '\\$routeProvider.when(\'$1\', {template: \'$2\', controller: $3});'
 '.text.html':
   '|currency':
     'prefix': '|'
@@ -121,7 +121,7 @@
   '|uppercase':
     'prefix': '|'
     'body': '|uppercase'
-'.text.html .meta.tag':
+'.text.html, .meta.tag':
   'ngRepeat':
     'prefix': 'repeat'
     'body': 'ng-repeat="${1:(${2:key}, ${3:value})} in ${4:dataset}"'


### PR DESCRIPTION
A few small issues from the Textmate conversion.
- Replaced `$TM_JAVASCRIPT_TERMINATOR` with semi-colons
- Removed escaping on `$`s in the snippet body
- Inserted a comma into `'.text.html, .meta.tag':` to fix the html snippets
