### PR TITLE
Update js-templates.cson (fix deprecated promise usage)

### DIFF
--- a/snippets/js-templates.cson
+++ b/snippets/js-templates.cson
@@ -180,12 +180,12 @@
     "prefix": "nghttp"
     "body": """
       $http({method: '${1:GET}', url: '$2'})
-      .success(function(data, status, headers, config) {
-        $3
-      })
-      .error(function(data, status, headers, config) {
-        $4
-      });
+      .then(function successCallback(data, status, headers, config) {
+		$3
+	  }, 
+	  function errorCallback(data, status, headers, config) {
+		$4
+	  });
     """
   "copy":
     "prefix": "ngcopy"


### PR DESCRIPTION
As per angular docs: 

> The $http legacy promise methods success and error have been deprecated. Use the standard then method instead. If $httpProvider.useLegacyPromiseExtensions is set to false then these methods will throw $http/legacy error.
