### PR TITLE
Correct highlighting of ng-repeat-start and ng-repeat-end attributes

### DIFF
--- a/grammars/angularjs.cson
+++ b/grammars/angularjs.cson
@@ -116,7 +116,7 @@
         'non-bindable|' +
         'open|options|' +
         'paste|pluralize|' +
-        'readonly|repeat|repeat-start|repeat-end|' +
+        'readonly|repeat-start|repeat-end|repeat|' +
         'selected|show|src|srcset|style|strict-di|submit|switch|switch-when|switch-default|' +
         'transclude|' +
         'value|' +

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -45,6 +45,15 @@ describe 'directive grammar', ->
 
       expect(lines[0][3]).toEqual value: 'NG-REPEAT', scopes: ['text.html.angular', 'meta.tag.block.any.html', 'meta.attribute.html.angular', 'entity.other.attribute-name.html.angular']
 
+    it 'tokenizes ng-repeat-start and ng-repeat-end attribute', ->
+      lines = grammar.tokenizeLines '''
+        <div ng-repeat-start></div>
+        <div ng-repeat-end></div>
+      '''
+
+      expect(lines[0][3]).toEqual value: 'ng-repeat-start', scopes: ['text.html.angular', 'meta.tag.block.any.html', 'meta.attribute.html.angular', 'entity.other.attribute-name.html.angular']
+      expect(lines[1][3]).toEqual value: 'ng-repeat-end', scopes: ['text.html.angular', 'meta.tag.block.any.html', 'meta.attribute.html.angular', 'entity.other.attribute-name.html.angular']
+
     it 'tokenizes ng-controller attribute in body tag', ->
       lines = grammar.tokenizeLines '''
         <body ng-controller="TestCtrl">


### PR DESCRIPTION
First, thanks for keeping up this package!

I spotted a minor bug when using ng-repeat-start and ng-repeat-end attributes. They are higlighted as ng-repeat.

![screen shot 2016-01-11 at 11 32 57](https://cloud.githubusercontent.com/assets/116486/12231389/5744cdb8-b857-11e5-85bc-90db67b615d0.png)

Fix with corresponding test attached.